### PR TITLE
feat: [1/6] bootstrap config and validation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func NewRootCommand() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "healthd",
+		Short: "Host health-check daemon",
+	}
+
+	root.AddCommand(newValidateCommand())
+	return root
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/uinaf/healthd/internal/config"
+)
+
+func newValidateCommand() *cobra.Command {
+	var configPath string
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate healthd configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolvedPath, err := config.ResolvePath(configPath)
+			if err != nil {
+				return err
+			}
+
+			if _, err := config.LoadFromPath(resolvedPath); err != nil {
+				return err
+			}
+
+			cmd.Printf("config is valid: %s\n", resolvedPath)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", fmt.Sprintf("config file path (default: %s)", config.DefaultConfigPath))
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/uinaf/healthd
+
+go 1.22
+
+require (
+	github.com/BurntSushi/toml v1.5.0
+	github.com/spf13/cobra v1.10.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+const (
+	DefaultConfigPath = "~/.config/healthd/config.toml"
+	EnvConfigPath     = "HEALTHD_CONFIG"
+)
+
+type Config struct {
+	Interval string        `toml:"interval"`
+	Timeout  string        `toml:"timeout"`
+	Checks   []CheckConfig `toml:"check"`
+}
+
+type CheckConfig struct {
+	Name     string `toml:"name"`
+	Command  string `toml:"command"`
+	Interval string `toml:"interval"`
+	Timeout  string `toml:"timeout"`
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Interval: "60s",
+		Timeout:  "10s",
+	}
+}
+
+func ResolvePath(cliPath string) (string, error) {
+	for _, candidate := range []string{cliPath, os.Getenv(EnvConfigPath), DefaultConfigPath} {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		return expandPath(candidate)
+	}
+
+	return "", errors.New("unable to resolve config path")
+}
+
+func LoadFromPath(path string) (Config, error) {
+	path, err := expandPath(path)
+	if err != nil {
+		return Config{}, err
+	}
+
+	cfg := DefaultConfig()
+	meta, err := toml.DecodeFile(path, &cfg)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to decode config %q: %w", path, err)
+	}
+
+	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+		return Config{}, fmt.Errorf("unknown config fields: %s", joinKeys(undecoded))
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return Config{}, fmt.Errorf("invalid config %q: %w", path, err)
+	}
+
+	return cfg, nil
+}
+
+func (c Config) Validate() error {
+	if err := validateDurationField("interval", c.Interval); err != nil {
+		return err
+	}
+
+	if err := validateDurationField("timeout", c.Timeout); err != nil {
+		return err
+	}
+
+	if len(c.Checks) == 0 {
+		return errors.New("at least one [[check]] entry is required")
+	}
+
+	for i, check := range c.Checks {
+		prefix := fmt.Sprintf("check[%d]", i)
+		if strings.TrimSpace(check.Name) == "" {
+			return fmt.Errorf("%s.name is required", prefix)
+		}
+		if strings.TrimSpace(check.Command) == "" {
+			return fmt.Errorf("%s.command is required", prefix)
+		}
+		if check.Interval != "" {
+			if err := validateDurationField(prefix+".interval", check.Interval); err != nil {
+				return err
+			}
+		}
+		if check.Timeout != "" {
+			if err := validateDurationField(prefix+".timeout", check.Timeout); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateDurationField(name, value string) error {
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return fmt.Errorf("%s must be a valid duration: %w", name, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("%s must be greater than zero", name)
+	}
+	return nil
+}
+
+func expandPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("path is empty")
+	}
+
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("determine user home: %w", err)
+		}
+		if path == "~" {
+			path = home
+		} else {
+			path = filepath.Join(home, path[2:])
+		}
+	}
+
+	return filepath.Clean(path), nil
+}
+
+func joinKeys(keys []toml.Key) string {
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key.String())
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolvePathPrecedence(t *testing.T) {
+	t.Setenv(EnvConfigPath, "/tmp/from-env.toml")
+
+	path, err := ResolvePath("/tmp/from-flag.toml")
+	if err != nil {
+		t.Fatalf("ResolvePath() error = %v", err)
+	}
+	if path != "/tmp/from-flag.toml" {
+		t.Fatalf("expected flag path, got %q", path)
+	}
+
+	path, err = ResolvePath("")
+	if err != nil {
+		t.Fatalf("ResolvePath() error = %v", err)
+	}
+	if path != "/tmp/from-env.toml" {
+		t.Fatalf("expected env path, got %q", path)
+	}
+
+	t.Setenv(EnvConfigPath, "")
+	path, err = ResolvePath("")
+	if err != nil {
+		t.Fatalf("ResolvePath() error = %v", err)
+	}
+	if !strings.HasSuffix(path, filepath.FromSlash(".config/healthd/config.toml")) {
+		t.Fatalf("expected default path suffix, got %q", path)
+	}
+}
+
+func TestLoadFromPathValid(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	path := writeTempConfig(t, `
+interval = "30s"
+timeout = "5s"
+
+[[check]]
+name = "disk"
+command = "df -h"
+`)
+
+	cfg, err := LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath() error = %v", err)
+	}
+
+	if cfg.Interval != "30s" || cfg.Timeout != "5s" {
+		t.Fatalf("unexpected top-level values: %+v", cfg)
+	}
+	if len(cfg.Checks) != 1 || cfg.Checks[0].Name != "disk" {
+		t.Fatalf("unexpected checks: %+v", cfg.Checks)
+	}
+}
+
+func TestLoadFromPathUsesDefaults(t *testing.T) {
+	path := writeTempConfig(t, `
+[[check]]
+name = "disk"
+command = "df -h"
+`)
+
+	cfg, err := LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath() error = %v", err)
+	}
+	if cfg.Interval != "60s" || cfg.Timeout != "10s" {
+		t.Fatalf("expected defaults, got interval=%q timeout=%q", cfg.Interval, cfg.Timeout)
+	}
+}
+
+func TestLoadFromPathRejectsUnknownField(t *testing.T) {
+	path := writeTempConfig(t, `
+interval = "30s"
+timeout = "5s"
+extra = true
+
+[[check]]
+name = "disk"
+command = "df -h"
+`)
+
+	_, err := LoadFromPath(path)
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "unknown config fields") {
+		t.Fatalf("expected unknown fields error, got %v", err)
+	}
+}
+
+func TestLoadFromPathRejectsUnknownNestedField(t *testing.T) {
+	path := writeTempConfig(t, `
+interval = "30s"
+timeout = "5s"
+
+[[check]]
+name = "disk"
+command = "df -h"
+unknown = true
+`)
+
+	_, err := LoadFromPath(path)
+	if err == nil {
+		t.Fatal("expected error for unknown nested field")
+	}
+	if !strings.Contains(err.Error(), "unknown config fields") {
+		t.Fatalf("expected unknown fields error, got %v", err)
+	}
+}
+
+func TestLoadFromPathRejectsInvalidConfig(t *testing.T) {
+	path := writeTempConfig(t, `
+interval = "not-a-duration"
+timeout = "5s"
+
+[[check]]
+name = "disk"
+command = "df -h"
+`)
+
+	_, err := LoadFromPath(path)
+	if err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+	if !strings.Contains(err.Error(), "invalid config") {
+		t.Fatalf("expected invalid config error, got %v", err)
+	}
+}
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"os"
+
+	"github.com/uinaf/healthd/cmd"
+)
+
+func main() {
+	if err := cmd.NewRootCommand().Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Fixes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced healthd CLI with a config validation command.
  * Added TOML configuration support for defining health checks (name, command, intervals, timeouts) with sensible defaults and path resolution (flag, env, or default, including ~ expansion).
  * Startup wired to the new CLI.

* **Tests**
  * Added tests covering path resolution, config loading, defaults, and validation (including rejection of unknown/invalid fields).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->