### PR TITLE
feat: [2/6] add check runner, expectations, and filtering

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/uinaf/healthd/internal/config"
+	"github.com/uinaf/healthd/internal/runner"
+)
+
+func newCheckCommand() *cobra.Command {
+	var configPath string
+	var only []string
+	var groups []string
+
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Run health checks once",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolvedPath, err := config.ResolvePath(configPath)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := config.LoadFromPath(resolvedPath)
+			if err != nil {
+				return err
+			}
+
+			checks := runner.FilterChecks(cfg.Checks, only, groups)
+			if len(checks) == 0 {
+				return errors.New("no checks matched filters")
+			}
+
+			results := runner.RunChecks(cmd.Context(), checks, cfg.Timeout)
+			for _, result := range results {
+				cmd.Printf("%s [%s]: %s (%s)\n", result.Name, emptyIfBlank(result.Group), passFail(result.Passed), result.Reason)
+
+				if strings.TrimSpace(result.Stdout) != "" {
+					cmd.Printf("  stdout: %s\n", strings.TrimSpace(result.Stdout))
+				}
+				if strings.TrimSpace(result.Stderr) != "" {
+					cmd.Printf("  stderr: %s\n", strings.TrimSpace(result.Stderr))
+				}
+			}
+
+			if !runner.AllPassed(results) {
+				return errors.New("one or more checks failed")
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", fmt.Sprintf("config file path (default: %s)", config.DefaultConfigPath))
+	cmd.Flags().StringSliceVar(&only, "only", nil, "only run checks by name (repeat flag or pass comma-separated names)")
+	cmd.Flags().StringSliceVar(&groups, "group", nil, "only run checks by group (repeat flag or pass comma-separated groups)")
+	return cmd
+}
+
+func passFail(passed bool) string {
+	if passed {
+		return "pass"
+	}
+	return "fail"
+}
+
+func emptyIfBlank(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "-"
+	}
+	return v
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ func NewRootCommand() *cobra.Command {
 		Short: "Host health-check daemon",
 	}
 
+	root.AddCommand(newCheckCommand())
 	root.AddCommand(newValidateCommand())
 	return root
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,0 +1,258 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/uinaf/healthd/internal/config"
+)
+
+type CheckResult struct {
+	Name      string
+	Group     string
+	Command   string
+	Stdout    string
+	Stderr    string
+	ExitCode  int
+	Duration  time.Duration
+	Passed    bool
+	TimedOut  bool
+	Reason    string
+	Timestamp time.Time
+}
+
+func RunChecks(ctx context.Context, checks []config.CheckConfig, defaultTimeout string) []CheckResult {
+	results := make([]CheckResult, 0, len(checks))
+	for _, check := range checks {
+		results = append(results, runCheck(ctx, check, defaultTimeout))
+	}
+	return results
+}
+
+func FilterChecks(checks []config.CheckConfig, only []string, groups []string) []config.CheckConfig {
+	nameFilter := toSet(only)
+	groupFilter := toSet(groups)
+
+	filtered := make([]config.CheckConfig, 0, len(checks))
+	for _, check := range checks {
+		if len(nameFilter) > 0 {
+			if _, ok := nameFilter[check.Name]; !ok {
+				continue
+			}
+		}
+		if len(groupFilter) > 0 {
+			if _, ok := groupFilter[check.Group]; !ok {
+				continue
+			}
+		}
+		filtered = append(filtered, check)
+	}
+
+	return filtered
+}
+
+func AllPassed(results []CheckResult) bool {
+	for _, result := range results {
+		if !result.Passed {
+			return false
+		}
+	}
+	return true
+}
+
+func runCheck(parent context.Context, check config.CheckConfig, defaultTimeout string) CheckResult {
+	start := time.Now()
+	result := CheckResult{
+		Name:      check.Name,
+		Group:     check.Group,
+		Command:   check.Command,
+		ExitCode:  -1,
+		Passed:    false,
+		Timestamp: start,
+	}
+
+	timeout, err := resolveTimeout(check.Timeout, defaultTimeout)
+	if err != nil {
+		result.Reason = fmt.Sprintf("invalid timeout: %v", err)
+		result.Duration = time.Since(start)
+		return result
+	}
+
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", check.Command)
+	cmd.Env = mergedEnv(check.Env)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+	result.Stdout = stdout.String()
+	result.Stderr = stderr.String()
+	result.Duration = time.Since(start)
+
+	if ctx.Err() == context.DeadlineExceeded {
+		result.TimedOut = true
+		result.ExitCode = -1
+		result.Reason = "timed out"
+		return result
+	}
+
+	result.ExitCode = extractExitCode(runErr)
+	passed, reason := evaluateExpectations(check.Expect, result.Stdout, result.ExitCode)
+	result.Passed = passed
+	result.Reason = reason
+
+	if runErr != nil && result.Reason == "" {
+		result.Reason = runErr.Error()
+	}
+
+	return result
+}
+
+func resolveTimeout(checkTimeout string, defaultTimeout string) (time.Duration, error) {
+	raw := strings.TrimSpace(checkTimeout)
+	if raw == "" {
+		raw = strings.TrimSpace(defaultTimeout)
+	}
+	if raw == "" {
+		return 0, errors.New("missing timeout")
+	}
+	return time.ParseDuration(raw)
+}
+
+func mergedEnv(overrides map[string]string) []string {
+	envMap := map[string]string{}
+
+	for _, entry := range os.Environ() {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		envMap[key] = value
+	}
+
+	for key, value := range overrides {
+		envMap[key] = value
+	}
+
+	keys := make([]string, 0, len(envMap))
+	for key := range envMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	result := make([]string, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, key+"="+envMap[key])
+	}
+	return result
+}
+
+func extractExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+
+	return -1
+}
+
+func evaluateExpectations(expect config.ExpectConfig, stdout string, exitCode int) (bool, string) {
+	trimmed := strings.TrimSpace(stdout)
+
+	if !hasExpectation(expect) {
+		if exitCode == 0 {
+			return true, "ok"
+		}
+		return false, fmt.Sprintf("expected exit_code=0, got %d", exitCode)
+	}
+
+	if expect.ExitCode != nil && exitCode != *expect.ExitCode {
+		return false, fmt.Sprintf("expected exit_code=%d, got %d", *expect.ExitCode, exitCode)
+	}
+
+	if expect.Equals != nil && trimmed != *expect.Equals {
+		return false, fmt.Sprintf("expected equals %q", *expect.Equals)
+	}
+
+	if expect.Not != nil && trimmed == *expect.Not {
+		return false, fmt.Sprintf("expected output to not equal %q", *expect.Not)
+	}
+
+	if expect.Contains != nil && !strings.Contains(trimmed, *expect.Contains) {
+		return false, fmt.Sprintf("expected output to contain %q", *expect.Contains)
+	}
+
+	if expect.NotContains != nil && strings.Contains(trimmed, *expect.NotContains) {
+		return false, fmt.Sprintf("expected output to not contain %q", *expect.NotContains)
+	}
+
+	if expect.Min != nil || expect.Max != nil {
+		value, err := strconv.ParseFloat(trimmed, 64)
+		if err != nil {
+			return false, fmt.Sprintf("expected numeric output, got %q", trimmed)
+		}
+		if expect.Min != nil && value < *expect.Min {
+			return false, fmt.Sprintf("expected output >= %v", *expect.Min)
+		}
+		if expect.Max != nil && value > *expect.Max {
+			return false, fmt.Sprintf("expected output <= %v", *expect.Max)
+		}
+	}
+
+	if expect.Regex != nil {
+		re, err := regexp.Compile(*expect.Regex)
+		if err != nil {
+			return false, fmt.Sprintf("invalid regex: %v", err)
+		}
+		if !re.MatchString(trimmed) {
+			return false, fmt.Sprintf("expected output to match regex %q", *expect.Regex)
+		}
+	}
+
+	return true, "ok"
+}
+
+func hasExpectation(expect config.ExpectConfig) bool {
+	return expect.ExitCode != nil ||
+		expect.Equals != nil ||
+		expect.Not != nil ||
+		expect.Contains != nil ||
+		expect.NotContains != nil ||
+		expect.Min != nil ||
+		expect.Max != nil ||
+		expect.Regex != nil
+}
+
+func toSet(values []string) map[string]struct{} {
+	set := map[string]struct{}{}
+
+	for _, raw := range values {
+		for _, part := range strings.Split(raw, ",") {
+			value := strings.TrimSpace(part)
+			if value == "" {
+				continue
+			}
+			set[value] = struct{}{}
+		}
+	}
+
+	return set
+}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,0 +1,200 @@
+package runner
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/uinaf/healthd/internal/config"
+)
+
+func TestRunChecksExpectationANDCombinations(t *testing.T) {
+	okContains := "health"
+	okRegex := `^health:[0-9]+$`
+	notValue := "bad"
+	minValue := 10.0
+	maxValue := 20.0
+
+	checks := []config.CheckConfig{
+		{
+			Name:    "expect-all-pass",
+			Command: `printf "health:12"`,
+			Expect: config.ExpectConfig{
+				ExitCode:    intPtr(0),
+				Contains:    &okContains,
+				Not:         &notValue,
+				Regex:       &okRegex,
+				NotContains: strPtr("panic"),
+			},
+		},
+		{
+			Name:    "expect-fail-combo",
+			Command: `printf "bad"`,
+			Expect: config.ExpectConfig{
+				ExitCode: intPtr(0),
+				Contains: &okContains,
+			},
+		},
+		{
+			Name:    "expect-numeric-range-pass",
+			Command: `printf "15"`,
+			Expect: config.ExpectConfig{
+				Min: &minValue,
+				Max: &maxValue,
+			},
+		},
+		{
+			Name:    "expect-numeric-range-fail",
+			Command: `printf "21"`,
+			Expect: config.ExpectConfig{
+				Min: &minValue,
+				Max: &maxValue,
+			},
+		},
+	}
+
+	results := RunChecks(context.Background(), checks, "1s")
+	if len(results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(results))
+	}
+
+	if !results[0].Passed {
+		t.Fatalf("expected first check to pass, got %+v", results[0])
+	}
+
+	if results[1].Passed {
+		t.Fatalf("expected second check to fail, got %+v", results[1])
+	}
+	if !strings.Contains(results[1].Reason, "contain") {
+		t.Fatalf("expected contains failure reason, got %q", results[1].Reason)
+	}
+
+	if !results[2].Passed {
+		t.Fatalf("expected numeric range pass, got %+v", results[2])
+	}
+
+	if results[3].Passed {
+		t.Fatalf("expected numeric range failure, got %+v", results[3])
+	}
+	if !strings.Contains(results[3].Reason, "<=") {
+		t.Fatalf("expected max failure reason, got %q", results[3].Reason)
+	}
+}
+
+func TestRunChecksTimeoutBehavior(t *testing.T) {
+	check := config.CheckConfig{
+		Name:    "timeout-check",
+		Command: `sleep 0.2`,
+		Timeout: "50ms",
+	}
+
+	results := RunChecks(context.Background(), []config.CheckConfig{check}, "1s")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	result := results[0]
+	if !result.TimedOut {
+		t.Fatalf("expected timeout, got %+v", result)
+	}
+	if result.Passed {
+		t.Fatalf("expected timeout to fail, got %+v", result)
+	}
+	if result.Reason != "timed out" {
+		t.Fatalf("expected timeout reason, got %q", result.Reason)
+	}
+	if result.ExitCode != -1 {
+		t.Fatalf("expected exitCode -1 for timeout, got %d", result.ExitCode)
+	}
+}
+
+func TestRunChecksUsesEnvOverrides(t *testing.T) {
+	check := config.CheckConfig{
+		Name:    "env-check",
+		Command: `printf "$HEALTHD_TEST_VAR"`,
+		Env: map[string]string{
+			"HEALTHD_TEST_VAR": "override",
+		},
+	}
+
+	results := RunChecks(context.Background(), []config.CheckConfig{check}, "1s")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	result := results[0]
+	if strings.TrimSpace(result.Stdout) != "override" {
+		t.Fatalf("expected env override output, got %q", result.Stdout)
+	}
+}
+
+func TestFilterChecks(t *testing.T) {
+	checks := []config.CheckConfig{
+		{Name: "cpu", Group: "host"},
+		{Name: "disk", Group: "host"},
+		{Name: "api", Group: "service"},
+	}
+
+	onlyFiltered := FilterChecks(checks, []string{"cpu,api"}, nil)
+	if len(onlyFiltered) != 2 {
+		t.Fatalf("expected 2 checks for --only filter, got %d", len(onlyFiltered))
+	}
+
+	groupFiltered := FilterChecks(checks, nil, []string{"host"})
+	if len(groupFiltered) != 2 {
+		t.Fatalf("expected 2 checks for --group filter, got %d", len(groupFiltered))
+	}
+
+	combined := FilterChecks(checks, []string{"api"}, []string{"host"})
+	if len(combined) != 0 {
+		t.Fatalf("expected 0 checks for combined non-matching filters, got %d", len(combined))
+	}
+}
+
+func TestRunChecksDefaultExitCodeExpectation(t *testing.T) {
+	results := RunChecks(context.Background(), []config.CheckConfig{
+		{Name: "ok-default", Command: "true"},
+		{Name: "fail-default", Command: "false"},
+	}, "1s")
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results[0].Passed {
+		t.Fatalf("expected zero exit code to pass by default, got %+v", results[0])
+	}
+	if results[1].Passed {
+		t.Fatalf("expected non-zero exit code to fail by default, got %+v", results[1])
+	}
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func strPtr(v string) *string {
+	return &v
+}
+
+func TestRunChecksPerCheckTimeoutOverride(t *testing.T) {
+	check := config.CheckConfig{
+		Name:    "override-timeout",
+		Command: "sleep 0.1",
+		Timeout: "300ms",
+	}
+
+	start := time.Now()
+	results := RunChecks(context.Background(), []config.CheckConfig{check}, "50ms")
+	elapsed := time.Since(start)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].TimedOut {
+		t.Fatalf("expected per-check timeout override to prevent timeout, got %+v", results[0])
+	}
+	if elapsed < 80*time.Millisecond {
+		t.Fatalf("check finished too quickly, timeout override likely ignored: %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary
Implement issue #2 by adding a one-shot check runner with expectation evaluation and CLI filtering.

## Changes
- add `healthd check` command with `--only` and `--group` filters
- add command runner with per-check timeout enforcement and env overrides (`sh -c` execution)
- add expectation engine with AND semantics for `exit_code`, `equals`, `not`, `contains`, `not_contains`, `min`, `max`, `regex`
- add structured check results with fields for stdout/stderr/exitCode/duration/reason and execution metadata
- add focused tests for expectation combinations, timeout behavior, env override behavior, and filtering

## Validation
- `go fmt ./...`
- `go test ./...`

## Linked Issues
Fixes #2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "check" command to run health checks with per-check timeouts and summarized pass/fail output.
  * Filtering by name (--only) and group (--group); per-check grouping and environment overrides supported.
  * Rich expectations: exit codes, contains/not-contains, equality/not, numeric ranges, and regex matching; detailed reasons shown.

* **Tests**
  * Added comprehensive tests for config validation, expectation evaluation, timeouts, env overrides, and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->