### PR TITLE
feat: [6/6] rollout docs and cron migration plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ go run ./cmd/verify --min-coverage=50
 
 Bootstrapped repository + issue plan created.
 Implementation starts with config + validation and proceeds as stacked PRs.
+
+## Rollout Docs
+
+- Migration guide: `docs/rollout.md`
+- Operational runbook: `docs/runbook.md`
+- Default host config example: `examples/current-host.toml`

--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -1,0 +1,69 @@
+# healthd Rollout: Migration from cron
+
+This rollout migrates from `glitch-health-check` cron jobs to `healthd` daemon mode.
+
+## 1. Prepare config
+
+1. Copy `examples/current-host.toml` to your local config path.
+2. Adjust thresholds and service endpoints for this host.
+3. Validate config:
+
+```bash
+healthd validate --config ~/.config/healthd/config.toml
+```
+
+## 2. Shadow mode (48h)
+
+Run `healthd` in parallel with existing cron checks for 48 hours.
+
+1. Install daemon while keeping cron active:
+
+```bash
+healthd daemon install --config ~/.config/healthd/config.toml
+```
+
+2. Verify daemon is active:
+
+```bash
+healthd daemon status
+```
+
+3. Compare outputs at least every 12 hours:
+
+```bash
+healthd check --config ~/.config/healthd/config.toml --json
+```
+
+4. Collect alert stats and compare with existing cron alerts.
+
+## 3. Success metrics (must be explicit before cutover)
+
+- No missing critical incidents versus cron during the 48h shadow window.
+- False positive rate is equal to or lower than cron alerts.
+- `healthd daemon status` reports running for the full 48h.
+- `healthd notify test` succeeds for all production backends.
+
+## 4. Cutover checklist
+
+Complete all items before disabling cron:
+
+- [ ] 48h shadow mode completed
+- [ ] Success metrics met
+- [ ] On-call acknowledges alert quality is acceptable
+- [ ] `healthd daemon status` shows running with a PID
+- [ ] Rollback owner assigned
+
+Disable the cron job after checklist completion:
+
+```bash
+crontab -l | grep -v 'glitch-health-check' | crontab -
+```
+
+## 5. Post-cutover checks
+
+- Run `healthd check --config ~/.config/healthd/config.toml` once manually.
+- Confirm latest daemon logs are clean:
+
+```bash
+healthd daemon logs --lines 100
+```

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,43 @@
+# healthd Operational Runbook
+
+## Validation
+
+```bash
+healthd validate --config ~/.config/healthd/config.toml
+```
+
+Expected: `config is valid` message.
+
+## One-shot check
+
+```bash
+healthd check --config ~/.config/healthd/config.toml
+```
+
+Expected: grouped PASS/FAIL output and summary.
+
+## Daemon status
+
+```bash
+healthd daemon status
+```
+
+Expected: `status: running (pid <n>)` after installation.
+
+## Rollback
+
+Use rollback if alert quality regresses or daemon repeatedly exits.
+
+1. Stop/remove LaunchAgent:
+
+```bash
+healthd daemon uninstall
+```
+
+2. Re-enable previous cron checks:
+
+```bash
+( crontab -l; echo "*/5 * * * * /usr/local/bin/glitch-health-check" ) | crontab -
+```
+
+3. Verify cron entry exists and health checks resume.

--- a/examples/current-host.toml
+++ b/examples/current-host.toml
@@ -1,0 +1,43 @@
+interval = "60s"
+timeout = "10s"
+
+# Default host checks mirroring the current cron-based health coverage.
+[[check]]
+name = "disk-root"
+group = "host"
+command = "df -P / | awk 'NR==2 {print 100-$5}'"
+
+[check.expect]
+min = 10
+
+[[check]]
+name = "load-1m"
+group = "host"
+command = "uptime | awk -F'load averages?: ' '{print $2}' | awk -F', ' '{print $1}'"
+
+[check.expect]
+max = 8
+
+[[check]]
+name = "memory-available-mb"
+group = "host"
+command = "vm_stat | awk '/Pages free|Pages speculative/ {sum += $3} END {print int(sum*4096/1024/1024)}'"
+
+[check.expect]
+min = 512
+
+[[check]]
+name = "api-health"
+group = "service"
+command = "curl -fsS --max-time 5 http://127.0.0.1:3000/healthz >/dev/null"
+
+[check.expect]
+exit_code = 0
+
+[notify]
+cooldown = "5m"
+
+[[notify.backend]]
+name = "ops-webhook"
+type = "webhook"
+url = "https://example.internal/healthd-alerts"


### PR DESCRIPTION
## Summary
Add v1 rollout documentation and migration assets for moving from `glitch-health-check` cron checks to `healthd` daemon workflow.

## Changes
- add default host migration config at `examples/current-host.toml`
- add `docs/rollout.md` with 48-hour shadow mode, signal/noise comparison flow, explicit success metrics, and cutover checklist
- include explicit cutover step to disable `glitch-health-check` cron only after validation
- add `docs/runbook.md` for operational commands: `validate`, `check`, `daemon status`, and rollback procedure
- link rollout docs from `README.md`

## Validation
- `go fmt ./...`
- `go test ./...`

## Linked Issues
Fixes #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive rollout documentation including migration guide, shadow mode validation with parallel execution, verification metrics, and cutover checklist.
  * Added operational runbook with validation, monitoring, and rollback procedures.
  * Added example host configuration demonstrating health check setup, service monitoring, and webhook-based alert notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->