### PR TITLE
ci: harden release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Etc/UTC
+    commit-message:
+      prefix: ci
+      include: scope
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ steps.go-version.outputs.version }}
           cache: true
@@ -59,6 +59,9 @@ jobs:
     needs: [verify]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment:
+      name: release
+      deployment: false
     concurrency:
       group: release-${{ github.repository }}-main
       cancel-in-progress: false
@@ -70,7 +73,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: true
@@ -88,10 +91,10 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ steps.go-version.outputs.version }}
-          cache: true
+          cache: false
           cache-dependency-path: |
             **/go.sum
 
@@ -100,16 +103,16 @@ jobs:
       # `new_release_version` for downstream steps.
       - name: Run semantic-release
         id: release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@16ca923e6ccbb50770c415a0ccd43709a8c5f7a4 # v4
         with:
           extra_plugins: |
             conventional-changelog-conventionalcommits@7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: glitch418x
-          GIT_AUTHOR_EMAIL: 189487110+glitch418x@users.noreply.github.com
-          GIT_COMMITTER_NAME: glitch418x
-          GIT_COMMITTER_EMAIL: 189487110+glitch418x@users.noreply.github.com
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
       # semantic-release creates the tag via the GitHub Release API; pull all
       # tags so we can detect one at HEAD (whether just-created or already
@@ -140,7 +143,7 @@ jobs:
 
       - name: Run GoReleaser
         if: steps.tag.outputs.present == 'true'
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -152,6 +155,6 @@ jobs:
 
       - name: Attest build provenance
         if: steps.tag.outputs.present == 'true'
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
           subject-path: "dist/healthd_*.tar.gz"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,8 +65,8 @@ brews:
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     directory: Formula
     commit_author:
-      name: glitch418x
-      email: 189487110+glitch418x@users.noreply.github.com
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
     commit_msg_template: "healthd: bump to {{ .Tag }}"
     homepage: "https://github.com/uinaf/healthd"
     description: "Pluggable local host health-check daemon"


### PR DESCRIPTION
## Summary

Harden the Go CLI release, artifact attestation, and Homebrew tap update workflow around the live `release` GitHub Environment.

## Changed

- Pins checkout/setup/release/attestation actions and adds Dependabot refreshes.
- Routes release through the `release` Environment.
- Disables release dependency caching.

## Risks

Homebrew publishing depends on `TAP_GITHUB_TOKEN` having write access to `uinaf/homebrew-tap`.

## Verification

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `mise exec -- go run ./cmd/verify`
- `codex-security:security-scan` diff scan: no reportable findings

## Complexity

Reduced.
