### PR TITLE
ci(release): migrate Homebrew publish to uinaf-release-bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
             healthd
             homebrew-tap
           permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Read Go version from .tool-versions
         id: go-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,7 @@ jobs:
       group: release-${{ github.repository }}-main
       cancel-in-progress: false
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
       id-token: write
       attestations: write
     steps:
@@ -78,6 +76,18 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Create release bot token
+        id: release-bot
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.UINAF_RELEASE_APP_ID }}
+          private-key: ${{ secrets.UINAF_RELEASE_APP_PRIVATE_KEY }}
+          owner: uinaf
+          repositories: |
+            healthd
+            homebrew-tap
+          permission-contents: write
 
       - name: Read Go version from .tool-versions
         id: go-version
@@ -109,11 +119,11 @@ jobs:
           extra_plugins: |
             conventional-changelog-conventionalcommits@7.0.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
+          GIT_AUTHOR_NAME: uinaf-release-bot[bot]
+          GIT_AUTHOR_EMAIL: 312581908+uinaf-release-bot[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: uinaf-release-bot[bot]
+          GIT_COMMITTER_EMAIL: 312581908+uinaf-release-bot[bot]@users.noreply.github.com
 
       # semantic-release creates the tag via the GitHub Release API; pull all
       # tags so we can detect one at HEAD (whether just-created or already
@@ -124,10 +134,9 @@ jobs:
       # Gate GoReleaser on "is there a tag at HEAD?" rather than
       # `steps.release.outputs.new_release_published`. Re-running the job
       # after a partial failure (semantic-release succeeded, GoReleaser
-      # failed mid-flight, e.g. transient `TAP_GITHUB_TOKEN` outage) still
-      # publishes binaries to the existing GitHub Release because the tag
-      # is now there. Without this, the second run would short-circuit and
-      # leave the release without binaries.
+      # failed mid-flight) still publishes binaries to the existing GitHub
+      # Release because the tag is now there. Without this, the second run
+      # would short-circuit and leave the release without binaries.
       - name: Detect tag at HEAD
         id: tag
         shell: bash
@@ -150,8 +159,8 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.release-bot.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
 
       - name: Attest build provenance

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,11 +62,11 @@ brews:
       owner: uinaf
       name: homebrew-tap
       branch: main
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
     commit_author:
-      name: github-actions[bot]
-      email: 41898282+github-actions[bot]@users.noreply.github.com
+      name: uinaf-release-bot[bot]
+      email: 312581908+uinaf-release-bot[bot]@users.noreply.github.com
     commit_msg_template: "healthd: bump to {{ .Tag }}"
     homepage: "https://github.com/uinaf/healthd"
     description: "Pluggable local host health-check daemon"


### PR DESCRIPTION
## Summary

- Mint a short-lived `uinaf-release-bot` installation token inside the protected `release` Environment
- Scope the token to `healthd` + `homebrew-tap` with Contents write only
- Keep the workflow `GITHUB_TOKEN` contents-read; use the App token for semantic-release and GoReleaser/tap writes
- Attribute tap commits to `uinaf-release-bot[bot]`

## Changed

- `.github/workflows/ci.yml` — App token minting and credential wiring
- `.goreleaser.yaml` — `HOMEBREW_TAP_TOKEN` + bot commit author

## Review aids

```mermaid
flowchart TD
  A[push to protected main] --> B[verify]
  B --> C[release Environment]
  C --> D[mint uinaf-release-bot token]
  D --> E[semantic-release tag + notes]
  E --> F[GoReleaser binaries]
  F --> G[homebrew-tap formula commit]
  D -.->|Contents write only| H[healthd + homebrew-tap]
```

## Risks

- Release fails until the `release` Environment has `UINAF_RELEASE_APP_ID` (variable) and `UINAF_RELEASE_APP_PRIVATE_KEY` (secret) seeded
- Keep `TAP_GITHUB_TOKEN` until a live App-backed release succeeds

## Verification

- [ ] PR `verify` job green
- [ ] Seed `release` Environment App identity before merge
- [ ] Post-merge: release/tap mutations attributed to `uinaf-release-bot[bot]`
- [ ] Token target list cannot mutate unrelated repos

## Complexity

Small credential cutover; release path shape unchanged.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate releases and Homebrew tap publishing to short‑lived `uinaf-release-bot` GitHub App tokens, removing the long‑lived PAT. Write access (Contents, Issues, PRs) is scoped to `healthd` and `homebrew-tap`; `GITHUB_TOKEN` stays read‑only.

- **Refactors**
  - Mint a scoped App token in the protected `release` environment via `actions/create-github-app-token` with Contents/Issues/PR write.
  - Use the App token for `semantic-release` and GoReleaser; set `HOMEBREW_TAP_TOKEN` and attribute commits to `uinaf-release-bot[bot]`.
  - Update workflow permissions to `contents: read`; keep `id-token` and attestations unchanged.
  - Swap `.goreleaser.yaml` token reference and commit author to the bot.

- **Migration**
  - Add `UINAF_RELEASE_APP_ID` (variable) and `UINAF_RELEASE_APP_PRIVATE_KEY` (secret) to the `release` environment before merge.

<sup>Written for commit d70865828d15b7421182780f9d2314d4493fceeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

