### PR TITLE
ci(release): resolve releaser bot user id at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,14 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
+      # GitHub links bot commits when the noreply email uses `{user-id}+{slug}[bot]@…`.
+      - name: Resolve release bot identity
+        id: release-bot-identity
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
       - name: Read Go version from .tool-versions
         id: go-version
         shell: bash
@@ -123,9 +131,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_AUTHOR_EMAIL: 312581908+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_COMMITTER_EMAIL: 312581908+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
 
       # semantic-release creates the tag via the GitHub Release API; pull all
       # tags so we can detect one at HEAD (whether just-created or already

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,14 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
-        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
+            echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot]" >&2
+            exit 1
+          fi
+          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
 
       - name: Read Go version from .tool-versions
         id: go-version
@@ -172,6 +179,8 @@ jobs:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           HOMEBREW_TAP_TOKEN: ${{ steps.release-bot.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
+          RELEASE_BOT_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
+          RELEASE_BOT_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
 
       - name: Attest build provenance
         if: steps.tag.outputs.present == 'true'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,8 +65,8 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
     commit_author:
-      name: uinaf-releaser[bot]
-      email: 312581908+uinaf-releaser[bot]@users.noreply.github.com
+      name: "{{ .Env.RELEASE_BOT_NAME }}"
+      email: "{{ .Env.RELEASE_BOT_EMAIL }}"
     commit_msg_template: "healthd: bump to {{ .Tag }}"
     homepage: "https://github.com/uinaf/healthd"
     description: "Pluggable local host health-check daemon"


### PR DESCRIPTION
## Summary
- Resolve `uinaf-releaser` bot user id at runtime for linked noreply emails
- Drop hard-coded `312581908` from release commit identity

## Test plan
- [ ] CI green on this PR
- [ ] Next release attributes commits to `uinaf-releaser[bot]`

## Review aids
Runtime lookup: `gh api /users/${app-slug}[bot] --jq .id` → `{id}+{slug}[bot]@users.noreply.github.com`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI resolves the `uinaf-releaser[bot]` user ID at runtime and builds the noreply email dynamically so release and Homebrew tap commits link to the bot. Removes the hard-coded `312581908` and validates the resolved ID.

- **Bug Fixes**
  - Resolve the bot ID via `gh api "/users/${APP_SLUG}[bot]" --jq .id` in a multiline script; validate it’s numeric.
  - Use the ID for `GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_EMAIL` and pass `RELEASE_BOT_NAME`/`RELEASE_BOT_EMAIL` to `goreleaser` to set brew commit authors.

<sup>Written for commit 05a44e39d6d2d7f8abbd785cc18c4b3668492e82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation by dynamically resolving the GitHub App bot identity, ensuring generated commit author and committer details remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->