### PR TITLE
fix(release): retry immutable attestation verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,4 +228,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
-        run: gh release verify "$RELEASE_TAG"
+        run: |
+          for attempt in {1..12}; do
+            if gh release verify "$RELEASE_TAG"; then
+              exit 0
+            fi
+            if (( attempt == 12 )); then
+              exit 1
+            fi
+            sleep 5
+          done


### PR DESCRIPTION
## Summary

Retry release verification for up to one minute while GitHub publishes the automatically generated immutable-release attestation.

## Review aids

This is the same bounded external-consistency retry proven by the tccutil-rs v0.2.12 release. It does not repeat builds, uploads, or publication.

## Verification

- actionlint
- git diff --check
- `go run ./cmd/verify`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry release verification in CI to wait for GitHub’s immutable-release attestation, preventing flaky failures. Tries for ~60s without repeating builds or uploads.

- **Bug Fixes**
  - Wrap `gh release verify "$RELEASE_TAG"` in `.github/workflows/ci.yml` with 12 attempts and 5s sleeps.
  - Exit early on success; fail only after the final attempt.

<sup>Written for commit afee9319b485f8d20984fe809526a27685767e11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release verification reliability by retrying checks when verification is temporarily unavailable.
  * Verification now makes multiple attempts before reporting failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->