### PR TITLE
fix(release): sign Homebrew formula update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,10 +188,39 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
-          HOMEBREW_TAP_TOKEN: ${{ steps.release-bot.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
-          RELEASE_BOT_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          RELEASE_BOT_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+
+      - name: Check out Homebrew tap
+        if: steps.tag.outputs.present == 'true' && steps.release-state.outputs.published != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: uinaf/homebrew-tap
+          token: ${{ steps.release-bot.outputs.token }}
+          path: homebrew-tap
+          ref: main
+          persist-credentials: false
+
+      - name: Stage Homebrew formula
+        if: steps.tag.outputs.present == 'true' && steps.release-state.outputs.published != 'true'
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          cp dist/homebrew/Formula/healthd.rb homebrew-tap/Formula/healthd.rb
+          grep -F "$RELEASE_TAG" homebrew-tap/Formula/healthd.rb
+          git -C homebrew-tap diff --check
+
+      - name: Commit Homebrew formula
+        if: steps.tag.outputs.present == 'true' && steps.release-state.outputs.published != 'true'
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: "healthd ${{ steps.tag.outputs.tag }}"
+          repo: uinaf/homebrew-tap
+          branch: main
+          file_pattern: Formula/healthd.rb
+          repository: homebrew-tap
+        env:
+          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
 
       - name: Verify draft artifacts
         if: steps.tag.outputs.present == 'true' && steps.release-state.outputs.published != 'true'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,16 +63,12 @@ release:
 
 brews:
   - name: healthd
+    skip_upload: true
     repository:
       owner: uinaf
       name: homebrew-tap
       branch: main
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
-    commit_author:
-      name: "{{ .Env.RELEASE_BOT_NAME }}"
-      email: "{{ .Env.RELEASE_BOT_EMAIL }}"
-    commit_msg_template: "healthd: bump to {{ .Tag }}"
     homepage: "https://github.com/uinaf/healthd"
     description: "Pluggable local host health-check daemon"
     license: "MIT"


### PR DESCRIPTION
## Summary

- keep GoReleaser as the formula generator but disable its unsigned tap upload
- commit the generated formula with the pinned GitHub App-aware Planetscale action
- keep formula publication before immutable release publication so failures remain safely retryable

## Review aids

```mermaid
flowchart LR
  G[GoReleaser generates formula] --> P[GitHub App signed tap commit]
  P --> V[Verify draft assets]
  V --> I[Publish immutable release]
```

## Verification

- `actionlint .github/workflows/ci.yml`
- `go run ./cmd/verify`
- `mise x goreleaser@2.17.1 -- goreleaser release --snapshot --clean`
- generated `dist/homebrew/Formula/healthd.rb` confirmed

## Risk

The failed `v0.5.2` release is still an unpublished mutable draft. After this lands, that failed draft/tag can be removed and the same version recreated through the corrected pipeline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sign Homebrew formula updates by committing to `uinaf/homebrew-tap` with a GitHub App token instead of letting `goreleaser` push unsigned updates. Keeps formula publish before the immutable release so failures are safe to retry.

- **Bug Fixes**
  - Set `brews[].skip_upload: true` in `.goreleaser.yaml` and removed tap token/author config.
  - In CI, check out `uinaf/homebrew-tap`, copy `dist/homebrew/Formula/healthd.rb`, and commit via `planetscale/ghcommit-action`.
  - Verify draft artifacts before publishing.

- **Migration**
  - If a previous release is a mutable draft, delete the draft and tag, then re-run the release to recreate the version.

<sup>Written for commit 8a44fcbcc3370a63b13706c78c337e1ee1fa6ab2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

