### PR TITLE
fix(release): use native GitHub App signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,39 +188,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.release-bot.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
-
-      - name: Check out Homebrew tap
-        if: steps.tag.outputs.present == 'true' && steps.release-state.outputs.published != 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: uinaf/homebrew-tap
-          token: ${{ steps.release-bot.outputs.token }}
-          path: homebrew-tap
-          ref: main
-          persist-credentials: false
-
-      - name: Stage Homebrew formula
-        if: steps.tag.outputs.present == 'true' && steps.release-state.outputs.published != 'true'
-        env:
-          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          set -euo pipefail
-          cp dist/homebrew/Formula/healthd.rb homebrew-tap/Formula/healthd.rb
-          grep -F "$RELEASE_TAG" homebrew-tap/Formula/healthd.rb
-          git -C homebrew-tap diff --check
-
-      - name: Commit Homebrew formula
-        if: steps.tag.outputs.present == 'true' && steps.release-state.outputs.published != 'true'
-        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
-        with:
-          commit_message: "healthd ${{ steps.tag.outputs.tag }}"
-          repo: uinaf/homebrew-tap
-          branch: main
-          file_pattern: Formula/healthd.rb
-          repository: homebrew-tap
-        env:
-          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
 
       - name: Verify draft artifacts
         if: steps.tag.outputs.present == 'true' && steps.release-state.outputs.published != 'true'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,12 +63,15 @@ release:
 
 brews:
   - name: healthd
-    skip_upload: true
     repository:
       owner: uinaf
       name: homebrew-tap
       branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
+    commit_author:
+      use_github_app_token: true
+    commit_msg_template: "healthd: bump to {{ .Tag }}"
     homepage: "https://github.com/uinaf/healthd"
     description: "Pluggable local host health-check daemon"
     license: "MIT"


### PR DESCRIPTION
## Summary

- replace the temporary external tap-commit action with GoReleaser's native GitHub App signing mode
- keep the release and signed Homebrew formula update in the existing Ubuntu job
- remove the extra checkout, staging, and commit workflow steps

## Review aids

```mermaid
flowchart LR
  G[GoReleaser creates assets and formula] --> A[GitHub App API commit]
  A --> S[GitHub signs tap commit]
  S --> I[Publish immutable release]
```

## Verification

- `actionlint .github/workflows/ci.yml`
- `go run ./cmd/verify`
- GoReleaser v2.17.1 config parsed successfully; only the pre-existing `brews` deprecation remains
- GoReleaser v2.17.1 source confirms `use_github_app_token` omits the committer so GitHub signs as the App

## Risk

This intentionally triggers one patch release to prove the native signed commit against the live Homebrew tap ruleset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Homebrew tap updates to native GitHub App signing in GoReleaser. This simplifies the workflow and ensures commits to `uinaf/homebrew-tap` are signed by the App.

- **Refactors**
  - Configure `brews.repository.token`, `commit_author.use_github_app_token: true`, and a commit message template in `.goreleaser.yaml`.
  - Set `HOMEBREW_TAP_TOKEN` for the release step.
  - Remove manual checkout/stage/commit steps; keep release and tap update in the Ubuntu job.

<sup>Written for commit 889adb01b844f18c38c633d7f7021ae6d91feef3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

