### PR TITLE
ci(release): retry draft discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,17 @@ jobs:
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          is_draft="$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)"
+          is_draft=""
+          for attempt in {1..12}; do
+            if is_draft="$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft 2>/dev/null)"; then
+              break
+            fi
+            if (( attempt == 12 )); then
+              echo "release $RELEASE_TAG did not become visible after $attempt attempts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
           echo "published=$([[ "$is_draft" == "false" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Run GoReleaser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,16 +177,21 @@ jobs:
         run: |
           set -euo pipefail
           is_draft=""
+          release_error_file="$(mktemp)"
+          trap 'rm -f "$release_error_file"' EXIT
           for attempt in {1..12}; do
-            if is_draft="$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft 2>/dev/null)"; then
+            if is_draft="$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft 2>"$release_error_file")"; then
               break
             fi
             if (( attempt == 12 )); then
-              echo "release $RELEASE_TAG did not become visible after $attempt attempts" >&2
+              cat "$release_error_file" >&2
+              echo "release $RELEASE_TAG lookup failed after $attempt attempts" >&2
               exit 1
             fi
             sleep 5
           done
+          rm -f "$release_error_file"
+          trap - EXIT
           echo "published=$([[ "$is_draft" == "false" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Run GoReleaser

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -17,7 +17,9 @@ Conventional Commits drive the bump (see `.releaserc.json`):
 
 1. `verify` runs with read-only credentials
 2. Protected `release` Environment mints a short-lived `uinaf-releaser` installation token scoped to `healthd` + `homebrew-tap`
-3. `semantic-release` creates the version tag and a mutable draft GitHub Release
+3. `semantic-release` creates the version tag and a mutable draft GitHub
+   Release; authenticated tag discovery retries for up to one minute and fails
+   if the expected draft remains unavailable
 4. GoReleaser adopts the draft, publishes darwin/arm64 + darwin/amd64 archives, and updates `uinaf/homebrew-tap`
 5. The workflow publishes the draft only after provenance succeeds, then verifies GitHub's immutable-release attestation
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -18,7 +18,7 @@ Conventional Commits drive the bump (see `.releaserc.json`):
 1. `verify` runs with read-only credentials
 2. Protected `release` Environment mints a short-lived `uinaf-releaser` installation token scoped to `healthd` + `homebrew-tap`
 3. `semantic-release` creates the version tag and a mutable draft GitHub
-   Release; authenticated tag discovery retries for up to one minute and fails
+   Release; authenticated release lookup retries for up to one minute and fails
    if the expected draft remains unavailable
 4. GoReleaser adopts the draft, publishes darwin/arm64 + darwin/amd64 archives, and updates `uinaf/homebrew-tap`
 5. The workflow publishes the draft only after provenance succeeds, then verifies GitHub's immutable-release attestation


### PR DESCRIPTION
## Summary

Harden mutable draft discovery against GitHub release API propagation delays.

## Changes

- Retry authenticated tag lookup for up to one minute.
- Fail explicitly if the expected release never appears.
- Document the fail-closed automation contract.

## Validation

- [x] `go run ./cmd/verify`
- [x] New behavior covered by workflow validation
- [x] Docs updated
- [x] `actionlint .github/workflows/ci.yml`

## Risks

A persistent API or authentication failure now waits for the bounded retry window before failing. Release mutation remains unchanged.

## Linked Issues

Cross-repository release hardening after a confirmed false-green draft race in Slopwake.
