### PR TITLE
chore: pin Go toolchain to 1.26.6

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.0
+golang 1.26.5

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.5
+golang 1.26.6

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/uinaf/healthd
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/uinaf/healthd
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
## Summary

Use current stable Go 1.26.6 consistently in local development and both CI jobs.

## Changes

- Pin .tool-versions to Go 1.26.6.
- Add the exact Go 1.26.6 toolchain directive while retaining Go 1.26.0 language compatibility.

## Validation

- [x] go run ./cmd/verify passes locally (fmt + lint + test + coverage gate)
- [ ] Pre-push hook is active (git config core.hooksPath .git-hooks)
- [ ] New behavior covered by tests (unit, integration, or e2e)
- [ ] Manual smoke against healthd check / healthd run / healthd status if user-facing
- [ ] Docs updated (AGENTS.md, README.md, docs/, operator skill) if behavior or commands changed

## Risks

Low. This changes compiler patch level only.

## Linked Issues

None.