### PR TITLE
docs: strip em dashes, use the house H1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ go build -o ~/.local/bin/healthd .
 
 ## Boundaries
 
-- Detect and report only — no auto-remediation
+- Detect and report only; no auto-remediation
 - Parse config into typed structs; reject unknown keys
 - Keep packages focused and testable
 
@@ -37,8 +37,8 @@ git config core.hooksPath .git-hooks
 
 ## Docs
 
-- [Architecture](docs/ARCHITECTURE.md) — components and check lifecycle
-- [Contributing](CONTRIBUTING.md) — setup, verify, pull requests
-- [Releases](docs/RELEASES.md) — Conventional Commits publish path
-- [Security](https://github.com/uinaf/healthd/security/policy) — private vulnerability reporting
-- [Operator skill](skills/healthd-operator/SKILL.md) — install and operate on a host
+- [Architecture](docs/ARCHITECTURE.md): components and check lifecycle
+- [Contributing](CONTRIBUTING.md): setup, verify, pull requests
+- [Releases](docs/RELEASES.md): Conventional Commits publish path
+- [Security](https://github.com/uinaf/healthd/security/policy): private vulnerability reporting
+- [Operator skill](skills/healthd-operator/SKILL.md): install and operate on a host

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ go test ./e2e/cli/... -v
 ## Pull Requests
 
 - Keep changes focused on one concern
-- Use Conventional Commits (`feat:`, `fix:`, `docs:`, …) — they drive releases
+- Use Conventional Commits (`feat:`, `fix:`, `docs:`, …); they drive releases
 - Fill the pull request template and include validation evidence
 - Update docs when behavior or commands change
 - Keep vulnerability reports out of public issues; use [Security](https://github.com/uinaf/healthd/security/policy)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![healthd — pluggable host health check daemon in Go.](https://uinaf.dev/og/banner/healthd.png)
 
-# healthd
+# uinaf/healthd
 
 Lightweight host health daemon for one machine: scheduled checks, machine-readable status, and alerts on fail/recover transitions.
 
@@ -58,10 +58,10 @@ More complete host profiles: [examples/current-host.toml](examples/current-host.
 
 ## Docs
 
-- [Architecture](docs/ARCHITECTURE.md) — components, lifecycle, design choices
-- [Contributing](CONTRIBUTING.md) — setup, verify, pull requests
-- [Releases](docs/RELEASES.md) — Conventional Commits publish path
-- [Security](https://github.com/uinaf/healthd/security/policy) — private vulnerability reporting
+- [Architecture](docs/ARCHITECTURE.md): components, lifecycle, design choices
+- [Contributing](CONTRIBUTING.md): setup, verify, pull requests
+- [Releases](docs/RELEASES.md): Conventional Commits publish path
+- [Security](https://github.com/uinaf/healthd/security/policy): private vulnerability reporting
 
 ## License
 

--- a/skills/healthd-operator/SKILL.md
+++ b/skills/healthd-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: healthd-operator
-description: Operate healthd safely on a local host: detect environment, install/build binary, bootstrap config, validate and run one-shot checks, test notifications, inspect alert history. Use when asked to deploy healthd, troubleshoot health checks, migrate from cron, or verify alert delivery. Daemon lifecycle (start/stop/restart) is owned by an external supervisor (process-compose, systemd, launchd) — this skill drives healthd directly, not the supervisor.
+description: Operate healthd safely on a local host: detect environment, install/build binary, bootstrap config, validate and run one-shot checks, test notifications, inspect alert history. Use when asked to deploy healthd, troubleshoot health checks, migrate from cron, or verify alert delivery. Daemon lifecycle (start/stop/restart) is owned by an external supervisor (process-compose, systemd, launchd); this skill drives healthd directly, not the supervisor.
 homepage: https://github.com/uinaf/healthd
 metadata:
   {
@@ -53,7 +53,7 @@ Use this skill for practical host operations. Prefer reversible steps and show c
    - Add an `ntfy` backend topic in config if none exists.
    - Run `healthd notify test --config <path> --backend <name-or-type>`.
 6. **Run continuously**
-   - Foreground (debugging): `healthd run --config <path>` — Ctrl-C to stop.
+   - Foreground (debugging): `healthd run --config <path>`; Ctrl-C to stop.
    - Production: configure your supervisor (process-compose, systemd unit, launchd plist) to invoke the same command. Lifecycle (start/stop/restart/logs) is the supervisor's responsibility, not healthd's.
 7. **Inspect history**
    - Recent transitions: `tail -n 20 ~/.local/state/healthd/alerts.log`
@@ -74,7 +74,7 @@ Use this skill for practical host operations. Prefer reversible steps and show c
 
 - Keep a backup before risky edits: `cp <path> <path>.bak`.
 - To rollback config quickly: `cp <path>.bak <path>`, then `healthd validate --config <path>`.
-- If supervised daemon behavior regresses, ask the supervisor to stop healthd, restore prior config or scheduler, and only then restart — confirm exact commands before running.
+- If supervised daemon behavior regresses, ask the supervisor to stop healthd, restore prior config or scheduler, and only then restart; confirm exact commands before running.
 
 ## References
 


### PR DESCRIPTION
## Problem

14 em dashes across the README, AGENTS.md, CONTRIBUTING, and the healthd-operator skill; the README H1 (`# healthd`) misses the house form.

## Solution

- Rewrite each em dash contextually (colon for link lists, semicolon for clauses); the banner alt keeps its one sanctioned em dash.
- H1 becomes `# uinaf/healthd`.
- Alongside this PR, the repository description moved to the brand register (`pluggable host health check daemon in Go`).

Part of the house gauntlet ([ffsstack#53](https://github.com/uinaf/ffsstack/issues/53)). Scan-baseline row: only `ci.yml` exists; gitleaks/trufflehog/actionlint pend the org-wide reusable-workflow call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)