### PR TITLE
ci: adopt the shared scan baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 1
+      default-days: 7
     groups:
       go-patch-minor:
         update-types: ["patch", "minor"]
@@ -19,7 +19,7 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 1
+      default-days: 7
     groups:
       actions-patch-minor:
         update-types: ["patch", "minor"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
 
       - name: Attest build provenance
         if: steps.tag.outputs.present == 'true' && steps.release-state.outputs.published != 'true'
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: "dist/healthd_*.tar.gz"
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,21 @@
+name: Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    uses: uinaf/.github/.github/workflows/scan.yml@main

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party reusable workflows track main by design; version and
+        # digest bumps land once in uinaf/.github for every adopter.
+        "uinaf/*": ref-pin
+        "*": hash-pin


### PR DESCRIPTION
## Problem

This repo runs only its build gate; no secret scanning or workflow lint.

## Solution

A thin caller for the shared `workflow_call` scan in [uinaf/.github](https://github.com/uinaf/.github) (gitleaks, trufflehog, actionlint, zizmor; digest-pinned there, bumped once for every adopter). Pilot repo for the rollout decided on [ffsstack#53](https://github.com/uinaf/ffsstack/issues/53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)