### PR TITLE
ci: least-privilege caller, first-party pin policy scoped to uinaf/.github

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,8 +9,7 @@ on:
     - cron: "23 6 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: scan-${{ github.workflow }}-${{ github.ref }}
@@ -18,4 +17,6 @@ concurrency:
 
 jobs:
   scan:
+    permissions:
+      contents: read
     uses: uinaf/.github/.github/workflows/scan.yml@main

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,5 +4,5 @@ rules:
       policies:
         # First-party reusable workflows track main by design; version and
         # digest bumps land once in uinaf/.github for every adopter.
-        "uinaf/*": ref-pin
+        "uinaf/.github": ref-pin
         "*": hash-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,5 +4,5 @@ rules:
       policies:
         # First-party reusable workflows track main by design; version and
         # digest bumps land once in uinaf/.github for every adopter.
-        "uinaf/.github": ref-pin
+        "uinaf/.github/*": ref-pin
         "*": hash-pin


### PR DESCRIPTION
## Problem

The pilot caller predates two rollout refinements: the zizmor first-party policy allowed `uinaf/*` (broader than the one repo that owns the shared workflow), and permissions sat at workflow level.

## Solution

`"uinaf/.github": ref-pin`, workflow-level `permissions: {}`, and `contents: read` granted on the scan job, matching every other adopter's caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)