### PR TITLE
docs: hold the docs to the house style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,6 @@ go test ./e2e/cli/... -v
 
 ## Releases
 
-Successful pushes to protected `main` evaluate Conventional Commits after
-`verify` passes. `fix`, `perf`, and `refactor` publish patches; `feat`
-publishes a minor; breaking changes publish a major; and docs, test, chore,
-build, and CI changes do not publish.
-
-The release job mints a short-lived `uinaf-releaser` token inside the
-`release` Environment, creates the tag and GitHub Release, and updates the
-Homebrew tap. See [Releases](docs/RELEASES.md) for the complete contract.
+Pushes to protected `main` publish automatically from Conventional Commits
+after `verify` passes. [Releases](docs/RELEASES.md) is the canonical contract:
+bump table, pipeline, and credentials.


### PR DESCRIPTION
CONTRIBUTING restated the release contract that `docs/RELEASES.md` already owns, in two paragraphs.

- **Spec:** the house writing style (outcome first, one fact per line, no duplicated homes for the same fact).
- **Applied:** the two release paragraphs collapse to one pointer at `docs/RELEASES.md`.
- **Verified:** `docs/RELEASES.md` carries both deduped facts, the bump table (lines 11 to 13) and the `uinaf-releaser` token and `release` Environment (lines 19 and 33); no em dashes outside the banner alt text; `CLAUDE.md` already symlinks `AGENTS.md`.
